### PR TITLE
Changed tests to use host fixture

### DIFF
--- a/molecule/default/tests/test_role.py
+++ b/molecule/default/tests/test_role.py
@@ -11,6 +11,6 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     'kubelet --version',
     'kubectl version --client=true'
 ])
-def test_java_tools(Command, command):
-    cmd = Command('. /etc/profile && ' + command)
+def test_java_tools(host, command):
+    cmd = host.run('. /etc/profile && ' + command)
     assert cmd.rc == 0


### PR DESCRIPTION
Other fixtures are deprecated and will be removed in 2.0 Testinfra release.