### PR TITLE
Removed unnecessary ca-certificates install

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,12 +4,6 @@
     that:
       - kubernetes_node_type in kubernetes_supported_node_type
 
-- name: ensure ca-certificates installed
-  become: yes
-  apt:
-    name: ca-certificates
-    state: present
-
 - name: ensure apt-transport-https installed
   become: yes
   apt:


### PR DESCRIPTION
It can reasonably be expected to be present. It was only added for an older version of Molecule.