### PR TITLE
Increased minimum Ansible version to 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ env:
 matrix:
   include:
     - env:
-        - MOLECULEW_ANSIBLE=2.4.6
+        - MOLECULEW_ANSIBLE=2.5.10
         - MOLECULE_SCENARIO=controller-ubuntu-min
     - env:
-        - MOLECULEW_ANSIBLE=2.4.6
+        - MOLECULEW_ANSIBLE=2.5.10
         - MOLECULE_SCENARIO=master-ubuntu-max
     - env:
         - MOLECULEW_ANSIBLE=2.7.0

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ manager.
 Requirements
 ------------
 
-* Ansible >= 2.4
+* Ansible >= 2.5
 
 * Linux Distribution
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Role for installing Kubernetes.
   company: GantSign Ltd.
   license: MIT
-  min_ansible_version: 2.4
+  min_ansible_version: 2.5
   platforms:
     - name: Ubuntu
       versions:


### PR DESCRIPTION
Ansible no longer supports version 2.5 and earlier.