### PR TITLE
Resolved apt module syntax deprecation warning

### DIFF
--- a/tasks/admin.yml
+++ b/tasks/admin.yml
@@ -2,11 +2,10 @@
 - name: install kubernetes (admin)
   become: yes
   apt:
-    name: '{{ item }}'
+    name:
+      - kubelet
+      - kubectl
+      - kubeadm
+      - kubernetes-cni
     state: present
-  with_items:
-    - kubelet
-    - kubectl
-    - kubeadm
-    - kubernetes-cni
   when: kubernetes_node_type == 'admin'

--- a/tasks/master.yml
+++ b/tasks/master.yml
@@ -2,9 +2,8 @@
 - name: install kubernetes (master)
   become: yes
   apt:
-    name: '{{ item }}'
+    name:
+      - kubelet
+      - kubectl
+      - kubernetes-cni
     state: present
-  with_items:
-    - kubelet
-    - kubectl
-    - kubernetes-cni

--- a/tasks/worker.yml
+++ b/tasks/worker.yml
@@ -2,8 +2,7 @@
 - name: install kubernetes (worker)
   become: yes
   apt:
-    name: '{{ item }}'
+    name:
+      - kubelet
+      - kubernetes-cni
     state: present
-  with_items:
-    - kubelet
-    - kubernetes-cni


### PR DESCRIPTION
```
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via
squash_actions is deprecated. Instead of using a loop to supply multiple items
and specifying `name: {{ item }}`, please use `name: [u'kubelet', u'kubectl', u
'kubernetes-cni']` and remove the loop. This feature will be removed in version
 2.11. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.
```